### PR TITLE
fix: resolve test and CI issues after rebase

### DIFF
--- a/e2e/config.json
+++ b/e2e/config.json
@@ -1,6 +1,6 @@
 {
   "public_pypi_url": "https://pypi.org/simple/",
-  "private_pypi_url": "http://localhost:8098/simple/",
+  "private_pypi_url": "http://127.0.0.1:8098/simple/",
   "port": 8099,
   "cache_enabled": false,
   "cache_size": 100,

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 package e2e
 
 import (
@@ -14,7 +17,7 @@ import (
 
 const (
 	proxyURL    = "http://localhost:8099"
-	privateURL  = "http://localhost:8098"
+	privateURL  = "http://127.0.0.1:8098"
 	testTimeout = 30 * time.Second
 )
 

--- a/e2e/run_tests.sh
+++ b/e2e/run_tests.sh
@@ -36,7 +36,7 @@ print_status "Waiting for environment to be ready..."
 sleep 45
 
 # Check if proxy is running
-if ! curl -f http://localhost:8099/simple/ >/dev/null 2>&1; then
+if ! timeout 10 curl -4 -f http://127.0.0.1:8099/simple/ >/dev/null 2>&1; then
     print_error "Proxy is not running"
     exit 1
 fi
@@ -45,7 +45,7 @@ print_status "Test environment is ready!"
 
 # Run the Go tests
 print_status "Running Go-based E2E tests..."
-go test -v -timeout 5m .
+go test -v -timeout 5m -tags=e2e .
 
 print_status "🎉 All tests completed!"
 print_status ""
@@ -64,4 +64,4 @@ print_status "  • Check proxy logs: ps aux | grep tejedor"
 print_status "  • Inspect container: podman exec -it tejedor-test-pypi bash"
 print_status "  • Test manually: curl http://localhost:8099/simple/"
 print_status ""
-print_status "⚠️  Note: Test environment is still running. Clean up when done." 
+print_status "⚠️  Note: Test environment is still running. Clean up when done."

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -80,7 +80,7 @@ $CONTAINER_ENGINE run -d --name tejedor-test-pypi -p 8098:8080 tejedor-test-pypi
 # Wait for PyPI server to be ready
 print_status "Waiting for PyPI server to be ready..."
 for i in {1..30}; do
-    if curl -f http://localhost:8098/simple/ >/dev/null 2>&1; then
+    if timeout 10 curl -4 -f http://127.0.0.1:8098/simple/ >/dev/null 2>&1; then
         print_status "PyPI server is ready"
         break
     fi
@@ -104,7 +104,7 @@ cd e2e
 cat > config.json << EOF
 {
   "public_pypi_url": "https://pypi.org/simple/",
-  "private_pypi_url": "http://localhost:8098/simple/",
+  "private_pypi_url": "http://127.0.0.1:8098/simple/",
   "port": 8099,
   "cache_enabled": false,
   "cache_size": 100,
@@ -119,7 +119,7 @@ TEJEDOR_PID=$!
 # Wait for tejedor to be ready
 print_status "Waiting for tejedor proxy to be ready..."
 for i in {1..15}; do
-    if curl -f http://localhost:8099/simple/ >/dev/null 2>&1; then
+    if timeout 10 curl -4 -f http://127.0.0.1:8099/simple/ >/dev/null 2>&1; then
         print_status "Tejedor proxy is ready"
         break
     fi
@@ -139,4 +139,4 @@ print_status "Tejedor PID: $TEJEDOR_PID"
 print_status "Test environment is running. Press Ctrl+C to stop."
 print_status "Proxy PID: $TEJEDOR_PID"
 print_status "Container: tejedor-test-pypi"
-wait $TEJEDOR_PID 
+wait $TEJEDOR_PID

--- a/e2e/start.sh
+++ b/e2e/start.sh
@@ -9,4 +9,4 @@ python3 populate_packages.py
 
 # Start PyPI server
 echo "Starting PyPI server on port 8080..."
-pypi-server run -p 8080 packages 
+pypi-server run -p 8080 -i 0.0.0.0 packages


### PR DESCRIPTION
- Add build tags to e2e tests to exclude from unit test runs
- Fix PyPI server binding to use correct interface (-i 0.0.0.0)
- Add timeouts to health checks in setup scripts
- Update URL configurations to use 127.0.0.1 consistently
- Fix test expectations to match actual URLs returned
- Separate unit tests and e2e tests in Makefile
- Update e2e test constants to use correct private URL

All tests now pass: unit tests, integration tests, and e2e tests working in both development and CI modes.