### PR TITLE
use pypiserver container (tiny)

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,11 +1,24 @@
-FROM registry.access.redhat.com/ubi9/ubi
-RUN dnf update -y && dnf install -y python3 python3-pip git gcc python3-devel --allowerasing && dnf clean all
-RUN mkdir -p /opt/pypi-server/packages /opt/pypi-server/private
-RUN pip3 install pypiserver
-COPY populate_packages.py /opt/pypi-server/populate_packages.py
-COPY populate-requirements.txt /opt/pypi-server/populate-requirements.txt
-COPY start.sh /opt/pypi-server/start.sh
-RUN chmod +x /opt/pypi-server/populate_packages.py /opt/pypi-server/start.sh
+FROM pypiserver/pypiserver:latest
+
+# Install additional tools needed for package downloading
+RUN apk add --no-cache python3 py3-pip git
+
+# Create directories for packages
+RUN mkdir -p /packages
+
+# Copy the population script and requirements
+COPY populate_packages.py /populate_packages.py
+COPY populate-requirements.txt /populate-requirements.txt
+COPY start.sh /start.sh
+
+# Make scripts executable
+RUN chmod +x /populate_packages.py /start.sh
+
+# Expose the port that pypiserver runs on
 EXPOSE 8098
-WORKDIR /opt/pypi-server
-CMD ["./start.sh"]
+
+# Set the working directory
+WORKDIR /
+
+# Override the entrypoint to use our custom start script
+ENTRYPOINT ["/start.sh"]

--- a/e2e/populate_packages.py
+++ b/e2e/populate_packages.py
@@ -3,9 +3,10 @@ import subprocess
 from pathlib import Path
 
 def download_package(package_spec):
-    packages_dir = Path("/opt/pypi-server/packages")
+    packages_dir = Path("/packages")
     packages_dir.mkdir(exist_ok=True)
     
+    # Use pip3 for Alpine Linux
     cmd = ["pip3", "download", "--no-deps", "--dest", str(packages_dir), package_spec]
     try:
         subprocess.run(cmd, check=True, capture_output=True)
@@ -26,7 +27,7 @@ def read_requirements_file(requirements_path):
     return packages
 
 def main():
-    requirements_file = Path("/opt/pypi-server/populate-requirements.txt")
+    requirements_file = Path("/populate-requirements.txt")
     
     if not requirements_file.exists():
         print(f"Error: Requirements file not found at {requirements_file}")

--- a/e2e/start.sh
+++ b/e2e/start.sh
@@ -7,6 +7,6 @@ echo "Starting PyPI server setup..."
 echo "Downloading packages from public PyPI..."
 python3 populate_packages.py
 
-# Start PyPI server
+# Start PyPI server using the official pypiserver
 echo "Starting PyPI server on port 8098..."
-pypi-server run -p 8098 -i 0.0.0.0 packages
+pypi-server run -p 8098 -i 0.0.0.0 /packages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image to use the official pypiserver base image and simplified the directory structure.
  * Adjusted scripts and paths to align with the new directory layout and Alpine Linux compatibility.
  * Updated startup scripts to use absolute paths and clarified comments regarding the PyPI server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->